### PR TITLE
pdflatex should be called twice to generate TOCs

### DIFF
--- a/vagga.yaml
+++ b/vagga.yaml
@@ -17,7 +17,9 @@ commands:
   pdflatex: !Command
     container: latex
     work-dir: /work/input
-    run: pdflatex -output-directory /work/output $@
+    run: |
+      pdflatex -output-directory /work/output $@
+      pdflatex -output-directory /work/output $@
     accepts-arguments: true
     environ:
       HOME: /tmp


### PR DESCRIPTION
It's wide spread practive to call latex build command twice: first generates the TOC files and references and second produces correct output file.

Running it just once can produce invalid pdf file with wrong references and empty table of content.
